### PR TITLE
Simplify Terraform configuration to only 2 resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,30 +23,14 @@ resource "random_string" "app_suffix" {
   upper   = false
 }
 
-resource "random_integer" "port" {
-  min = 8000
-  max = 9000
-}
-
-# Simple local file for testing
-resource "local_file" "test_config" {
-  content = templatefile("${path.module}/templates/simple-config.tpl", {
-    app_name    = var.app_name
-    environment = var.environment
-    port        = random_integer.port.result
-    suffix      = random_string.app_suffix.result
-  })
-  filename = "${path.module}/generated/test-config.json"
-}
-
 # Simple null resource for testing
 resource "null_resource" "simple_test" {
   triggers = {
-    app_name       = var.app_name
-    config_content = local_file.test_config.content
+    app_name = var.app_name
+    suffix   = random_string.app_suffix.result
   }
 
   provisioner "local-exec" {
-    command = "echo 'Testing Atlantis with ${var.app_name} in ${var.environment} environment'"
+    command = "echo 'Testing Atlantis with ${var.app_name}-${random_string.app_suffix.result} in ${var.environment} environment'"
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,17 +13,7 @@ output "random_suffix" {
   value       = random_string.app_suffix.result
 }
 
-output "random_port" {
-  description = "Random port generated for this run"
-  value       = random_integer.port.result
-}
-
 output "app_instance_id" {
   description = "Application instance identifier"
   value       = "${var.app_name}-${random_string.app_suffix.result}"
-}
-
-output "config_file_path" {
-  description = "Path to the generated config file"
-  value       = local_file.test_config.filename
 }


### PR DESCRIPTION
- Remove random_integer.port resource
- Remove local_file.test_config resource
- Keep only random_string.app_suffix and null_resource.simple_test
- Update outputs to match simplified configuration
- Plan now shows 'Plan: 2 to add, 0 to change, 0 to destroy'

This makes the Atlantis testing plan smaller and easier to review.